### PR TITLE
Redo the speed tier calculator to just calc on demand

### DIFF
--- a/BattleFactoryBuddy/Set.py
+++ b/BattleFactoryBuddy/Set.py
@@ -52,10 +52,10 @@ class Set:
         ivs = int(inputdict["Battle"])
         if ivs == 15 and inputdict["Round"] in ("6", "8"):
             ivs = 31
-        return self.calcspeedinternal(level, ivs)
+        return self.calcspeedraw(level, ivs)
 
     # Returns the speed value given the exact level and IVs.
-    def calcspeedinternal(self, level, ivs):
+    def calcspeedraw(self, level, ivs):
         return math.floor(
             (
                 math.floor(
@@ -103,7 +103,7 @@ class Set:
             self.moveList[3],
             self.nature,
             self.evs,
-            self.calcspeedinternal(level, ivs),
+            self.calcspeedraw(level, ivs),
         )
 
     # Returns a string representation of this set to use in tooltips.

--- a/BattleFactoryBuddy/SpeedQueryHandler.py
+++ b/BattleFactoryBuddy/SpeedQueryHandler.py
@@ -1,78 +1,86 @@
+import BattleFactoryBuddy.StaticDataHandler as StaticDataHandler
+
 # This class handles queries about speed tiers via a static method. It's not at all nice but as this is some
 # side functionality on the Buddy, and relatively straightforward, I'm not attempting to tidy it up for
 # first release. There's much more and better to be done here by someone at some point.
 
 class SpeedQueryHandler:
     
-    @staticmethod
-    def getspeedoutputs(inputdict):
+    def calcSpeedOutputs(inputdict):
         level = int(inputdict["Level"])
-        round = int(inputdict["Round"])
-        IVs = int(inputdict["IVs"])
+        round = int(inputdict["Round"])    
+        ivs = int(inputdict["IVs"])    
         
         if inputdict["yourspeed"] == '':
             inputdict["outputcol1"] = "<font size=\"20\"><b>Please input a speed</b></font><br>"
-            return(inputdict)
+            return(inputdict)     
 
-        refspeed = int(inputdict["yourspeed"])
-
-        column = 2
-        if level == 100:
-            column += 4
-        if IVs == 6:
-            column +=1
-        elif IVs == 15:
-            column +=2
-        elif IVs == 31:
-            column +=3
-        
-        sets = []
+        # Work out which sets are allowable in this round.
+        allowedRoundSets = []
         if level == 50:
             if round < 4:
                 inputdict["outputcol1"] = "<font size=\"20\"><b>Not supported for Level 50 rounds 1-3.</b></font><br>"
                 return(inputdict)
             elif round < 8:
-                sets.append(round - 3)
+                allowedRoundSets.append(round - 3)
             else:
-                sets=[1,2,3,4,5]
+                allowedRoundSets=[1,2,3,4,5]
         elif round < 5:
-            sets.append(round)
+            allowedRoundSets.append(round)
         else:
-            sets = [1,2,3,4,5,6]
-        
-        faster = ""
-        fastercount = 0
-        tied = ""
-        tiedcount = 0
-        slowerwithqc = ""
-        slowerwithqccount = 0
-        slower = ""    
-        slowercount = 0    
-        skip = True
-        with open("./BattleFactoryBuddy/Data/Pokemonspeedtiers.csv") as r:
-            for line in r:
-                splits = line.split(",")
-                if skip:
-                    skip = False
-                    continue
-                if int(splits[1]) not in sets:
-                    continue
-                if int(splits[column]) > refspeed:
-                    faster += splits[0] + ": " + splits[column] + "<br>"
-                    fastercount += 1
-                elif int(splits[column]) == refspeed:
-                    tied += splits[0] + ": " + splits[column] + "<br>"
-                    tiedcount += 1
-                elif (int(splits[column]) < refspeed) and splits[-1].strip() == "True":
-                    slowerwithqc += splits[0] + ": " + splits[column] + "<br>"
-                    slowerwithqccount += 1
-                else:                    
-                    slower += splits[0] + ": " + splits[column] + "<br>"
-                    slowercount += 1
-        total = fastercount+tiedcount+slowerwithqccount+slowercount
-        inputdict["outputcol1"] = "<h3>Faster: {:.2f}%</h3></br>".format(float(100*fastercount)/total) + faster
-        inputdict["outputcol2"] = "<h3>Tied: {:.2f}%</h3></br>".format(float(100*tiedcount)/total) + tied
-        inputdict["outputcol3"] = "<h3>Slower with Quick Claw: {:.2f}%</h3></br>".format(float(100*slowerwithqccount)/total) + slowerwithqc
-        inputdict["outputcol4"] = "<h3>Slower: {:.2f}%</h3></br>".format(float(100*slowercount)/total) + slower
+            allowedRoundSets = [1,2,3,4,5,6]        
 
-        return(inputdict)
+        # Calculate the speeds for all other allowable sets and sort them into the relevant buckets.
+        refspeed = int(inputdict["yourspeed"])
+        fasterList = []
+        tiedList = []
+        slowerQCList = []
+        slowerList = []
+
+        for set in StaticDataHandler.StaticDataHandler.getSetList():
+            if int(set.roundInfo) not in allowedRoundSets:
+                continue
+            setSpeed = set.calcspeedraw(level,ivs)
+            if setSpeed > refspeed:
+                fasterList.append((set.id, int(set.getuid()), setSpeed))
+            elif setSpeed == refspeed:
+                tiedList.append((set.id, int(set.getuid()), setSpeed))
+            elif set.item == "Quick Claw":
+                slowerQCList.append((set.id, int(set.getuid()), setSpeed))
+            else:
+                slowerList.append((set.id, int(set.getuid()), setSpeed))
+        
+        # Sort lists so that the faster mons are higher and then the higher ID
+        # mons within a tie are higher. As smaller number = higherid we have to take the 
+        # ID off the speedscore.
+        fasterList.sort(key=lambda tuple: tuple[2]*10000-tuple[1],reverse=True)        
+        fasterHtml = ""
+        for (id, unused, speed) in fasterList:
+            fasterHtml += "<br>" + id + ": " + str(speed)
+
+        tiedList.sort(key=lambda tuple: tuple[2]*10000-tuple[1],reverse=True)
+        tiedHtml = ""
+        for (id, unused, speed) in tiedList:
+            tiedHtml += "<br>" + id + ": " + str(speed)
+
+        slowerQCList.sort(key=lambda tuple: tuple[2]*10000-tuple[1],reverse=True)
+        slowerQcHtml = ""
+        for (id, unused, speed) in slowerQCList:
+            slowerQcHtml += "<br>" + id + ": " + str(speed)
+
+        slowerList.sort(key=lambda tuple: tuple[2]*10000-tuple[1],reverse=True)
+        slowerHtml = ""
+        for (id, unused, speed) in slowerList:
+            slowerHtml += "<br>" + id + ": " + str(speed)
+
+        # Output as HTML
+        total = len(fasterList) + len(tiedList) + len(slowerQCList) + len(slowerList)
+
+        inputdict["outputcol1"] = "<h3>Faster: {:.2f}%</h3></br>".format(float(100*len(fasterList))/total) + fasterHtml
+        inputdict["outputcol2"] = "<h3>Tied: {:.2f}%</h3></br>".format(float(100*len(tiedList))/total) + tiedHtml
+        inputdict["outputcol3"] = "<h3>Slower with Quick Claw: {:.2f}%</h3></br>".format(float(100*len(slowerQCList))/total) + slowerQcHtml
+        inputdict["outputcol4"] = "<h3>Slower: {:.2f}%</h3></br>".format(float(100*len(slowerList))/total) + slowerHtml
+        return inputdict
+        
+            
+

--- a/BattleFactoryBuddy/StaticDataGenerator.py
+++ b/BattleFactoryBuddy/StaticDataGenerator.py
@@ -62,29 +62,6 @@ def generateTeamList():
                     o.write(teamStr + "\n")
                 print("Written to ../Data/"+str(a) + "-" + str(b) + ".csv")
 
-# Calculate the speed for all possible opposing mons. This is all sets in both and l50 and OL and 3IV, 6IV, 15IV, 31IV.
-# How pokemon stats works means that some sets swap their order depending on the level and IV tier. We don't attempt to
-# address that here in the ordering and it is instead handled at query time.
-def generateSpeedList():
-    print("Creating Speed Tiers")
-    setList = StaticDataHandler.StaticDataHandler.getSetList()
-    # Use 31IV open level as the master. That's least likely to have ties.
-    speeddict = {}
-    for set in setList:
-        speed = set.calcspeedinternal(50,3)
-        if speed not in speeddict:
-            speeddict[speed] = []
-        speeddict[speed].append(set)
-    sortedspeeds = list(speeddict.keys())
-    sortedspeeds.sort(reverse=True)    
-
-    with open("./BattleFactoryBuddy/Data/Pokemonspeedtiers.csv","w") as r:
-        r.write("Pokemon,round,l50_3,l50_6,l50_15,l50_31,l100_3,l100_6,l100_15,l100_31,quickclaw\n")
-        for speed in sortedspeeds:
-            for set in speeddict[speed]:
-                r.write(",".join([set.id,str(set.roundInfo),str(set.calcspeedinternal(50,3)),str(set.calcspeedinternal(50,6)),str(set.calcspeedinternal(50,15)),str(set.calcspeedinternal(50,31)),str(set.calcspeedinternal(100,3)),str(set.calcspeedinternal(100,6)),str(set.calcspeedinternal(100,15)),str(set.calcspeedinternal(100,31)),str(set.item=="Quick Claw")+ "\n"]))
-    print("Done creating speed tiers!")
-
 # A utility function for checking the data on set moves and their phrases is consistent.
 # As an example, the base spreadsheet for factory had Registeel-3 as 0 0 4 4 whereas Amnesia
 # meant it should have been 0 1 4 4, this catches those issues (especially useful if you've edited the sets for some reason).
@@ -169,8 +146,7 @@ def generateTypeEffectivenessCode():
 
 if __name__ == "__main__":
     print("This will take a while (maybe 5-10 mins?), it gets faster as it goes though!")
-    validateSetInfo()
-    generateSpeedList()    
+    validateSetInfo()    
     generateTeamList()
     # Various utility functions that aren't needed to be run in most cases.
     # generateMoveList()

--- a/BattleFactoryBuddy/StaticDataHandler.py
+++ b/BattleFactoryBuddy/StaticDataHandler.py
@@ -10,7 +10,7 @@ class StaticDataHandler:
     # Loading and initialization of all static data used by the Buddy. This is loaded once and
     # is immutable over the lifetime of the app. Only exception are the team lists which are
     # loaded on demand to improve startup performance (but are also immutable).
-    version = "2.0.1"
+    version = "2.0.2"
 
     # Indexed by SetID (sequential numbers), contains Set objects.
     setDict = {}

--- a/BattleFactoryBuddy/views.py
+++ b/BattleFactoryBuddy/views.py
@@ -39,9 +39,12 @@ def setcalc(request):
 @csrf_exempt
 def speedcalc(request):
     if request.method == 'POST':        
+        t1_start = perf_counter() 
         context = request.POST.dict()                
-        context = SpeedQueryHandler.SpeedQueryHandler.getspeedoutputs(context)     
+        context = SpeedQueryHandler.SpeedQueryHandler.calcSpeedOutputs(context)     
         context["version"] = StaticDataHandler.StaticDataHandler.getVersion()   
+        t1_stop = perf_counter() 
+        print("Elapsed time: ", t1_stop - t1_start)
         return render(request, 'BattleFactoryBuddy/speedcalc.html', context)
     else:
         context = {}


### PR DESCRIPTION
This makes the code cleaner, let's us squash the bug where displayed speeds could sometimes be out of order and makes life easier for forks which may need to support a much wider number of IV tiers.